### PR TITLE
[FIX] 논문 정보 하나에 리뷰가 너무 많이 생기는 문제 수정

### DIFF
--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -445,7 +445,6 @@ export class StudentsService {
                 const currentHeadReviewer = currentReviewers.filter(
                   (reviewer) => reviewer.role === Role.COMMITTEE_CHAIR
                 )[0];
-                console.log(`심사위원장 교체?: ${headReviewerId} !== ${currentHeadReviewer.reviewerId}`)
                 if (headReviewerId && headReviewerId !== currentHeadReviewer.reviewerId) {
                   // 심사위원장 교체
 
@@ -453,9 +452,9 @@ export class StudentsService {
                   await tx.review.deleteMany({
                     where: {
                       reviewerId: currentHeadReviewer.reviewerId,
-                      thesisInfo: { processId: process.id }
-                    }
-                  })
+                      thesisInfo: { processId: process.id },
+                    },
+                  });
 
                   // process 수정
                   await tx.process.update({
@@ -535,7 +534,7 @@ export class StudentsService {
                     .map((advisor) => advisor.reviewerId);
                   const deleteAdvisorIds = currentAdvisorIds.filter((id) => !advisorIds.includes(id)); // 현재 지도교수 중 삭제될 지도교수
                   const newAdvisorIds = advisorIds.filter((id) => !currentAdvisorIds.includes(id)); // 새롭게 추가될 지도교수
-                  
+
                   // 지도 교수 삭제
                   if (deleteAdvisorIds.length !== 0) {
                     // review 삭제 (hard delete)
@@ -543,8 +542,8 @@ export class StudentsService {
                       where: {
                         reviewerId: { in: deleteAdvisorIds },
                         thesisInfo: { processId: process.id },
-                      }
-                    })
+                      },
+                    });
 
                     await tx.reviewer.deleteMany({
                       where: {
@@ -633,8 +632,8 @@ export class StudentsService {
                       where: {
                         reviewerId: { in: deleteCommitteeIds },
                         thesisInfo: { processId: process.id },
-                      }
-                    })
+                      },
+                    });
                     await tx.reviewer.deleteMany({
                       where: {
                         reviewerId: { in: deleteCommitteeIds },

--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -1729,7 +1729,7 @@ export class StudentsService {
         const revisionThesisInfo = process.thesisInfos.filter((thesisInfo) => thesisInfo.stage === Stage.REVISION)[0];
         // 존재하는 논문 정보에 대해 review data 미리 정리
         const reviewData = [];
-        if (preThesisInfo) {
+        if (foundStudent.studentProcess.currentPhase === Stage.PRELIMINARY) {
           reviewData.push({
             thesisInfoId: preThesisInfo.id,
             reviewerId,
@@ -1738,7 +1738,7 @@ export class StudentsService {
             isFinal: false,
           });
         }
-        if (mainThesisInfo) {
+        if (foundStudent.studentProcess.currentPhase === Stage.MAIN) {
           reviewData.push({
             thesisInfoId: mainThesisInfo.id,
             reviewerId,
@@ -1746,15 +1746,16 @@ export class StudentsService {
             presentationStatus: ReviewStatus.UNEXAMINED,
             isFinal: false,
           });
-        }
-        if (revisionThesisInfo) {
-          reviewData.push({
-            thesisInfoId: revisionThesisInfo.id,
-            reviewerId,
-            contentStatus: ReviewStatus.UNEXAMINED,
-            presentationStatus: ReviewStatus.PASS, // 수정지시사항 단계 구두 심사 없음
-            isFinal: false,
-          });
+          if (revisionThesisInfo) {
+            // 수정 지시 사항 단계가 있는 경우
+            reviewData.push({
+              thesisInfoId: revisionThesisInfo.id,
+              reviewerId,
+              contentStatus: ReviewStatus.UNEXAMINED,
+              presentationStatus: ReviewStatus.PASS, // 수정지시사항 단계 구두 심사 없음
+              isFinal: false,
+            });
+          }
         }
         // review 생성
         await tx.review.createMany({


### PR DESCRIPTION
작성자: @yesjuhee 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

Issue #112 관련 수정 내용입니다.
- 학생을 최초 생성할 때는 문제가 없지만, 생성된 학생의 심사위원장/심사위원/지도교수 (지도 관계)를 수정할 때의 로직에 오류가 있어 수정했습니다. 
- 엑셀을 이용해서 수정할 경우, 페이지에서 직접 수정할 경우(개별 API 사용) 두 가지 경우에 대해 모두 반영했습니다.

## 비고

- 전체 로직을 뜯어보기에는 좀 복잡해서 간단하게 눈으로 에러 사항만 체크해주시면 좋을 것 같습니다. 
- 지도 관계 변경에 관련해서 추가로 생길 수 있는 엣지 케이스들을 리뷰로 남기고 논의해봐도 좋을 것 같습니다!

### ⚠️  행정실에 전달 필요
- 학생의 지도 관계를 수정할 경우 reviewer에서 삭제된 교수가 작성한 **review도 모두 삭제(hard delete)** 됩니다.
- 즉 행정실에서 학생을 등록하는 <논문 심사> 단계에서 지도 관계를 수정할 경우에는 아무 문제가 없지만, **교수가 심사를 작성한 후에 지도 관계를 수정할 경우** 이전 정보는 보관되지 않는다는 것을 행정실에 명확히 전달드리는게 좋을 것 같습니다. (지도 관계는 심사 전에만 변경하는걸로..)

fix #112
