### PR TITLE
[FEAT] 학생, 교수, 학과 삭제 로직 변경 / 디비 스키마에 onDelete 조건들 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,7 +120,7 @@ model Review {
   thesisInfoId       Int?
   fileId             String?     @unique
   file               File?       @relation(fields: [fileId], references: [uuid])
-  reviewer           User?       @relation(fields: [reviewerId], references: [id], onDelete: Cascade)
+  reviewer           User?       @relation(fields: [reviewerId], references: [id], onDelete: SetNull)
   thesisInfo         ThesisInfo? @relation(fields: [thesisInfoId], references: [id], onDelete: Cascade)
 
   @@index([reviewerId], map: "review_reviewerId_fkey")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,9 +53,9 @@ model Process {
   studentId      Int?         @unique
   headReviewerId Int?
   phaseId        Int?
-  headReviewer   User?        @relation("headReviewer", fields: [headReviewerId], references: [id])
+  headReviewer   User?        @relation("headReviewer", fields: [headReviewerId], references: [id], onDelete: SetNull)
   phase          Phase?       @relation(fields: [phaseId], references: [id])
-  student        User?        @relation("student", fields: [studentId], references: [id])
+  student        User?        @relation("student", fields: [studentId], references: [id], onDelete: Cascade)
   reviewers      Reviewer[]
   thesisInfos    ThesisInfo[]
 
@@ -87,7 +87,7 @@ model ThesisInfo {
   processId   Int?
   reviews     Review[]
   thesisFiles ThesisFile[]
-  process     Process?     @relation(fields: [processId], references: [id])
+  process     Process?     @relation(fields: [processId], references: [id], onDelete: Cascade)
 
   @@index([processId], map: "thesis_info_processId_fkey")
   @@map("thesis_info")
@@ -99,8 +99,8 @@ model Reviewer {
   reviewerId Int?
   processId  Int?
   role       Role
-  process    Process? @relation(fields: [processId], references: [id])
-  reviewer   User?    @relation(fields: [reviewerId], references: [id])
+  process    Process? @relation(fields: [processId], references: [id], onDelete: Cascade)
+  reviewer   User?    @relation(fields: [reviewerId], references: [id], onDelete: Cascade)
 
   @@index([processId], map: "reviewer_processId_fkey")
   @@index([reviewerId], map: "reviewer_reviewerId_fkey")
@@ -120,8 +120,8 @@ model Review {
   thesisInfoId       Int?
   fileId             String?     @unique
   file               File?       @relation(fields: [fileId], references: [uuid])
-  reviewer           User?       @relation(fields: [reviewerId], references: [id])
-  thesisInfo         ThesisInfo? @relation(fields: [thesisInfoId], references: [id])
+  reviewer           User?       @relation(fields: [reviewerId], references: [id], onDelete: Cascade)
+  thesisInfo         ThesisInfo? @relation(fields: [thesisInfoId], references: [id], onDelete: Cascade)
 
   @@index([reviewerId], map: "review_reviewerId_fkey")
   @@index([thesisInfoId], map: "review_thesisInfoId_fkey")
@@ -151,7 +151,7 @@ model ThesisFile {
   thesisInfoId Int?
   fileId       String?        @unique
   file         File?          @relation(fields: [fileId], references: [uuid])
-  ThesisInfo   ThesisInfo?    @relation(fields: [thesisInfoId], references: [id])
+  ThesisInfo   ThesisInfo?    @relation(fields: [thesisInfoId], references: [id], onDelete: Cascade)
 
   @@index([thesisInfoId], map: "thesis_file_thesisInfoId_fkey")
   @@map("thesis_file")
@@ -167,7 +167,7 @@ model Achievements {
   authorType      AuthorType
   authorNumbers   Int
   userId          Int?
-  User            User?       @relation(fields: [userId], references: [id])
+  User            User?       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId], map: "achievements_userId_fkey")
   @@map("achievements")

--- a/src/modules/departments/departments.controller.ts
+++ b/src/modules/departments/departments.controller.ts
@@ -63,7 +63,7 @@ export class DepartmentsController {
   @Delete(":id")
   @ApiOperation({
     summary: "학과 삭제",
-    description: "학과 삭제",
+    description: "학과 삭제, 해당 학과 소속 학생들은 Cascade로 삭제됩니다.",
   })
   @UseUserTypeGuard([UserType.ADMIN])
   @ApiUnauthorizedResponse({ description: "[관리자] 로그인 후 접근 가능" })

--- a/src/modules/departments/departments.module.ts
+++ b/src/modules/departments/departments.module.ts
@@ -1,9 +1,11 @@
 import { Module } from "@nestjs/common";
 import { DepartmentsService } from "./departments.service";
 import { DepartmentsController } from "./departments.controller";
+import { StudentsModule } from "../students/students.module";
 
 @Module({
   controllers: [DepartmentsController],
   providers: [DepartmentsService],
+  imports: [StudentsModule],
 })
 export class DepartmentsModule {}

--- a/src/modules/departments/departments.service.ts
+++ b/src/modules/departments/departments.service.ts
@@ -2,10 +2,15 @@ import { PrismaService } from "src/config/database/prisma.service";
 import { BadRequestException, Injectable, InternalServerErrorException } from "@nestjs/common";
 import { CreateDepartmentDto } from "./dtos/create-department.dto";
 import { UpdateDepartmentQuery } from "./dtos/update-department-query.dto";
+import { UserType } from "@prisma/client";
+import { StudentsService } from "../students/students.service";
 
 @Injectable()
 export class DepartmentsService {
-  constructor(private readonly prismaService: PrismaService) {}
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly studentService: StudentsService
+  ) {}
   async getAllDepartments() {
     const departments = await this.prismaService.department.findMany({
       include: {
@@ -39,12 +44,24 @@ export class DepartmentsService {
   async deleteDepartment(id: number) {
     const department = await this.prismaService.department.findUnique({
       where: { id },
+      include: { users: true },
     });
-
     if (!department) {
       throw new BadRequestException("존재하지 않는 학과입니다.");
     }
 
+    // 소속 학생 삭제
+    const studentIds = department.users.filter((user) => user.type === UserType.STUDENT).map((student) => student.id);
+    for (const studentId of studentIds) {
+      try {
+        await this.studentService.deleteStudent(studentId);
+      } catch (error) {
+        console.log(error);
+        throw new InternalServerErrorException("해당 학과의 학생을 삭제하는 과정에서 오류 발생");
+      }
+    }
+
+    // 학과 삭제
     return this.prismaService.department.delete({
       where: { id },
     });

--- a/src/modules/files/files.module.ts
+++ b/src/modules/files/files.module.ts
@@ -5,5 +5,6 @@ import { FilesService } from "./files.service";
 @Module({
   controllers: [FilesController],
   providers: [FilesService],
+  exports: [FilesService],
 })
 export class FilesModule {}

--- a/src/modules/students/students.controller.ts
+++ b/src/modules/students/students.controller.ts
@@ -395,6 +395,7 @@ export class StudentsController {
     return new CommonResponseDto(reviewersDto);
   }
 
+  // 삭제
   @Delete("")
   @ApiOperation({
     summary: "학생 목록 삭제",
@@ -406,6 +407,19 @@ export class StudentsController {
   async deleteStudentsList() {
     await this.studentsService.deleteStudentsList();
 
+    return new CommonResponseDto();
+  }
+
+  @Delete("/:id")
+  @ApiOperation({
+    summary: "학생 삭제 API",
+    description: "아이디에 해당하는 학생을 DB에서 삭제하고, 관련 데이터와 파일도 모두 삭제한다.",
+  })
+  @UseUserTypeGuard([UserType.ADMIN])
+  @ApiUnauthorizedResponse({ description: "[관리자] 로그인 후 접근 가능" })
+  @ApiInternalServerErrorResponse({ description: "서버 내부 오류" })
+  async deleteStudent(@Param("id", PositiveIntPipe) studentId: number) {
+    await this.studentsService.deleteStudent(studentId);
     return new CommonResponseDto();
   }
 }

--- a/src/modules/students/students.module.ts
+++ b/src/modules/students/students.module.ts
@@ -8,5 +8,6 @@ import { FilesModule } from "../files/files.module";
   controllers: [StudentsController],
   providers: [StudentsService],
   imports: [AuthModule, FilesModule],
+  exports: [StudentsService],
 })
 export class StudentsModule {}

--- a/src/modules/students/students.module.ts
+++ b/src/modules/students/students.module.ts
@@ -2,12 +2,10 @@ import { Module } from "@nestjs/common";
 import { StudentsController } from "./students.controller";
 import { StudentsService } from "./students.service";
 import { AuthModule } from "../auth/auth.module";
-import { FilesModule } from "../files/files.module";
-
 @Module({
   controllers: [StudentsController],
   providers: [StudentsService],
-  imports: [AuthModule, FilesModule],
+  imports: [AuthModule],
   exports: [StudentsService],
 })
 export class StudentsModule {}

--- a/src/modules/students/students.module.ts
+++ b/src/modules/students/students.module.ts
@@ -2,10 +2,11 @@ import { Module } from "@nestjs/common";
 import { StudentsController } from "./students.controller";
 import { StudentsService } from "./students.service";
 import { AuthModule } from "../auth/auth.module";
+import { FilesModule } from "../files/files.module";
 
 @Module({
   controllers: [StudentsController],
   providers: [StudentsService],
-  imports: [AuthModule],
+  imports: [AuthModule, FilesModule],
 })
 export class StudentsModule {}

--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -25,7 +25,6 @@ import { validate } from "class-validator";
 import { UpdateThesisInfoDto } from "./dtos/update-thesis-info.dto";
 import { Readable } from "stream";
 import { UpdateSystemDto } from "./dtos/update-system.dto";
-import { file } from "jszip";
 
 @Injectable()
 export class StudentsService {

--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -1,4 +1,3 @@
-import { FilesService } from "./../files/files.service";
 import { ReviewerRoleQuery, UpdateReviewerQueryDto } from "./dtos/update-reviewer-query-dto";
 import { ThesisInfoQueryDto, ThesisQueryType } from "./dtos/thesis-info-query.dto";
 import {
@@ -30,8 +29,7 @@ import { UpdateSystemDto } from "./dtos/update-system.dto";
 export class StudentsService {
   constructor(
     private readonly prismaService: PrismaService,
-    private readonly authService: AuthService,
-    private readonly fileService: FilesService
+    private readonly authService: AuthService
   ) {}
 
   // 학생 생성 API


### PR DESCRIPTION
작성자: @yesjuhee 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

1. 디비 스키마 수정 (onDelete 조건 추가)
2. 단일 학생 삭제 API 구현: `DELETE /students/:id` - `deleteStudent()`
3. 학생 일괄 삭제 API 수정 `DELETE /students` - `deleteStudentList()`
4. 학과 삭제 API 수정

## 비고

1. 디비 스키마 수정
    - 행정실에서 사용할 DB에 `prisma db push` 필요 (데이터 삭제 없이 push 가능합니다.) 
    - 학생 삭제할 때 관련 정보들 다 Cascade 되도록 수정했습니다.
2. 단일 학생 삭제 API
3. 학생 일괄 삭제 API
    : 학생 삭제될 때 minIO에 있는 관련 파일들도 모두 삭제되도록 했는데 여기서 시간이 꽤 오래 걸릴 것 같습니다. 로컬로 테스트 돌려봤을때는 20명 지우는데 채감상 5~7초 정도? 실제 서비스에 쓸 때 문제 없을까요..?
4. 학과 삭제 API
    : ⚠️  학과 삭제될 때 해당 학과에 소속된 학생들도 모두 삭제되도록 수정했습니다(혹시 모를 오류 파티 방지). 이 부분 행정실에 안내해야 할 것 같습니다.

close #111
