### PR TITLE
[FIX] 학생 엑셀 대량 등록 에러 수정

### DIFF
--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -1028,7 +1028,7 @@ export class StudentsService {
         return students;
       },
       {
-        timeout: 10000,
+        timeout: 40000,
       }
     );
   }


### PR DESCRIPTION
작성자: @yesjuhee 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 100명 이상 등록 시 prisma transaction에서 timeout 에러가 나서 timeout 시간을 10초에서 40초로 수정했습니다.

## 비고

- 테스트 결과 200명 정도까지는 문제가 없는데 행정실에는 안전하게 ❗**최대 160명까지만 끊어서 등록**❗해달라고 전달해야할 것 같습니다.

close #110 
