### PR TITLE
[FIX] 학생 지도 관계 업데이트 오류 수정

### DIFF
--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -1723,15 +1723,6 @@ export class StudentsService {
     });
     if (foundReviewer) throw new BadRequestException("이미 해당 학생에 배정된 교수입니다.");
 
-    // 인원수 초과 확인
-    const currentReviewers = await this.prismaService.reviewer.findMany({
-      where: {
-        processId: process.id,
-        role,
-      },
-    });
-    if (currentReviewers.length === 2) throw new BadRequestException(`${role}가 이미 2명이므로 추가할 수 없습니다.`);
-
     try {
       await this.prismaService.$transaction(async (tx) => {
         // reviewer 생성
@@ -1836,16 +1827,6 @@ export class StudentsService {
 
     // 심사위원장인지 확인
     if (process.headReviewerId === reviewerId) throw new BadRequestException("심사위원장은 배정 취소할 수 없습니다.");
-
-    // 해당 역할의 교수가 2명인지 확인
-    const reviewerList = await this.prismaService.reviewer.findMany({
-      where: {
-        processId: process.id,
-        role: foundReviewer.role,
-      },
-    });
-    if (reviewerList.length < 2)
-      throw new BadRequestException(`${foundReviewer.role}이 2명일 때만 배정 취소가 가능합니다.`);
 
     // 배정 취소 (review, reviewer 삭제)
     try {


### PR DESCRIPTION
작성자: @yesjuhee 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- updateReviewer : 지도 관계 추가 API에서 배정 교수 숫자가 2명 넘어가는지 확인하는 로직 삭제 
- deleteReviewer : 지도 관계 삭제 API에서 배정 교수 숫자가 0명이 되지 않도록 확인하는 로직 삭제

## 비고

- 위의 배정 교수 숫자 확인하는 로직이 이미 프론트에서 처리되어서 자동으로 백엔드에서는 필요 없어지고 실제 서비스에서 에러가 발생하는 케이스
- 사실 백엔드 입장에서나 프론트 입장에서나 둘 다 에러가 아니었던 케이스여서 qa 아니면 발견하기 쉽지 않은 에러네요 🤔

close #127 
