### PR TITLE
[HOTFIX] 논문 수정시 발표파일만 업데이트하면 반영 안되는 오류 수정

### DIFF
--- a/src/modules/students/students.service.ts
+++ b/src/modules/students/students.service.ts
@@ -1537,22 +1537,27 @@ export class StudentsService {
           (thesisFile) => thesisFile.type === ThesisFileType.PRESENTATION
         )[0];
 
+        const fileUpdateData = [];
+        if (thesisFileUUID) {
+          fileUpdateData.push({
+            where: { id: preThesisFile.id },
+            data: { fileId: thesisFileUUID },
+          });
+        }
+        if (presentationFileUUID) {
+          fileUpdateData.push({
+            where: { id: prePPTFile.id },
+            data: { fileId: presentationFileUUID },
+          });
+        }
+
         return await this.prismaService.thesisInfo.update({
           where: { id: preThesisInfo.id },
           data: {
             title,
             abstract,
             thesisFiles: {
-              update: [
-                {
-                  where: { id: preThesisFile.id },
-                  data: { fileId: thesisFileUUID },
-                },
-                {
-                  where: { id: prePPTFile.id },
-                  data: { fileId: presentationFileUUID },
-                },
-              ],
+              update: fileUpdateData,
             },
           },
           include: {
@@ -1574,6 +1579,20 @@ export class StudentsService {
           (thesisFile) => thesisFile.type === ThesisFileType.PRESENTATION
         )[0];
 
+        const fileUpdateData = [];
+        if (thesisFileUUID) {
+          fileUpdateData.push({
+            where: { id: mainThesisFile.id },
+            data: { fileId: thesisFileUUID },
+          });
+        }
+        if (presentationFileUUID) {
+          fileUpdateData.push({
+            where: { id: mainPPTFile.id },
+            data: { fileId: presentationFileUUID },
+          });
+        }
+
         const thesisInfo = await this.prismaService.$transaction(async (tx) => {
           // 본심 논문 정보 업데이트
           const thesisData = await tx.thesisInfo.update({
@@ -1582,16 +1601,7 @@ export class StudentsService {
               title,
               abstract,
               thesisFiles: {
-                update: [
-                  {
-                    where: { id: mainThesisFile.id },
-                    data: { fileId: thesisFileUUID },
-                  },
-                  {
-                    where: { id: mainPPTFile.id },
-                    data: { fileId: presentationFileUUID },
-                  },
-                ],
+                update: fileUpdateData,
               },
             },
             include: {
@@ -1628,20 +1638,25 @@ export class StudentsService {
           (thesisFile) => thesisFile.type === ThesisFileType.REVISION_REPORT
         )[0];
 
+        const fileUpdateData = [];
+        if (thesisFileUUID) {
+          fileUpdateData.push({
+            where: { id: revisionThesisFile.id },
+            data: { fileId: thesisFileUUID },
+          });
+        }
+        if (revisionReportFileUUID) {
+          fileUpdateData.push({
+            where: { id: revisionReportFile.id },
+            data: { fileId: revisionReportFileUUID },
+          });
+        }
+
         return await this.prismaService.thesisInfo.update({
           where: { id: revisionThesisInfo.id },
           data: {
             thesisFiles: {
-              update: [
-                {
-                  where: { id: revisionThesisFile.id },
-                  data: { fileId: thesisFileUUID },
-                },
-                {
-                  where: { id: revisionReportFile.id },
-                  data: { fileId: revisionReportFileUUID },
-                },
-              ],
+              update: fileUpdateData,
             },
           },
           include: {

--- a/src/modules/theses/theses.service.ts
+++ b/src/modules/theses/theses.service.ts
@@ -36,22 +36,27 @@ export class ThesesService {
           (thesisFile) => thesisFile.type === ThesisFileType.PRESENTATION
         )[0];
 
+        const fileUpdateData = [];
+        if (thesisFileUUID) {
+          fileUpdateData.push({
+            where: { id: preThesisFile.id },
+            data: { fileId: thesisFileUUID },
+          });
+        }
+        if (presentationFileUUID) {
+          fileUpdateData.push({
+            where: { id: prePPTFile.id },
+            data: { fileId: presentationFileUUID },
+          });
+        }
+
         return await this.prismaService.thesisInfo.update({
           where: { id },
           data: {
             title,
             abstract,
             thesisFiles: {
-              update: [
-                {
-                  where: { id: preThesisFile.id },
-                  data: { fileId: thesisFileUUID },
-                },
-                {
-                  where: { id: prePPTFile.id },
-                  data: { fileId: presentationFileUUID },
-                },
-              ],
+              update: fileUpdateData,
             },
           },
           include: {
@@ -78,6 +83,20 @@ export class ThesesService {
           (thesisInfo) => thesisInfo.stage === Stage.REVISION
         )[0];
 
+        const fileUpdateData = [];
+        if (thesisFileUUID) {
+          fileUpdateData.push({
+            where: { id: mainThesisFile.id },
+            data: { fileId: thesisFileUUID },
+          });
+        }
+        if (presentationFileUUID) {
+          fileUpdateData.push({
+            where: { id: mainPPTFile.id },
+            data: { fileId: presentationFileUUID },
+          });
+        }
+
         const thesisInfo = await this.prismaService.$transaction(async (tx) => {
           // 본심 논문 정보 업데이트
           const thesisData = tx.thesisInfo.update({
@@ -86,16 +105,7 @@ export class ThesesService {
               title,
               abstract,
               thesisFiles: {
-                update: [
-                  {
-                    where: { id: mainThesisFile.id },
-                    data: { fileId: thesisFileUUID },
-                  },
-                  {
-                    where: { id: mainPPTFile.id },
-                    data: { fileId: presentationFileUUID },
-                  },
-                ],
+                update: fileUpdateData,
               },
             },
             include: {
@@ -139,6 +149,20 @@ export class ThesesService {
           (thesisInfo) => thesisInfo.stage === Stage.MAIN
         )[0];
 
+        const fileUpdateData = [];
+        if (thesisFileUUID) {
+          fileUpdateData.push({
+            where: { id: revisionThesisFile.id },
+            data: { fileId: thesisFileUUID },
+          });
+        }
+        if (revisionReportFileUUID) {
+          fileUpdateData.push({
+            where: { id: revisionReportFile.id },
+            data: { fileId: presentationFileUUID },
+          });
+        }
+
         const [thesisInfo] = await this.prismaService.$transaction([
           // 수정지시사항 논문 정보 업데이트
           this.prismaService.thesisInfo.update({
@@ -147,16 +171,7 @@ export class ThesesService {
               title,
               abstract,
               thesisFiles: {
-                update: [
-                  {
-                    where: { id: revisionThesisFile.id },
-                    data: { fileId: thesisFileUUID },
-                  },
-                  {
-                    where: { id: revisionReportFile.id },
-                    data: { fileId: revisionReportFileUUID },
-                  },
-                ],
+                update: fileUpdateData,
               },
             },
             include: {


### PR DESCRIPTION
작성자: @hynseok 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 논문 수정시 발표파일만 업데이트하면 반영 안되는 오류 수정.
- thesisFileUUID 혹은 presentationFileUUID가 있을때만 prisma 업데이트 쿼리에 담도록 수정했습니다.

## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.

close/resolve/fix #133
